### PR TITLE
Add responsive services section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -142,6 +142,37 @@ footer ul {
   margin-bottom: 1rem;
 }
 
+/* Services section */
+.services {
+  background: #121212;
+  color: #fff;
+}
+
+.service-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.service-card {
+  background: #1e1e1e;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.service-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+}
+
+.service-card i {
+  color: var(--primary-color);
+  margin-bottom: 1rem;
+}
+
 /* Responsive adjustments */
 @media (max-width: 600px) {
   header,

--- a/index.html
+++ b/index.html
@@ -71,6 +71,42 @@
                 </div>
             </div>
         </section>
+
+        <section class="services">
+            <h2>Nos services</h2>
+            <div class="service-cards">
+                <div class="service-card">
+                    <i class="fa-solid fa-laptop-code fa-2x" aria-hidden="true"></i>
+                    <h3>Cours en ligne interactifs</h3>
+                    <p>Des leçons dynamiques avec exercices en temps réel.</p>
+                </div>
+                <div class="service-card">
+                    <i class="fa-solid fa-file-lines fa-2x" aria-hidden="true"></i>
+                    <h3>Devoirs corrigés par des anciens</h3>
+                    <p>Recevez des corrections détaillées pour progresser.</p>
+                </div>
+                <div class="service-card">
+                    <i class="fa-solid fa-user-check fa-2x" aria-hidden="true"></i>
+                    <h3>Suivi individuel chaque semaine</h3>
+                    <p>Un tuteur dédié pour suivre vos avancées.</p>
+                </div>
+                <div class="service-card">
+                    <i class="fa-regular fa-circle-question fa-2x" aria-hidden="true"></i>
+                    <h3>Sessions de questions/réponses</h3>
+                    <p>Un temps régulier pour lever vos bloquages.</p>
+                </div>
+                <div class="service-card">
+                    <i class="fa-solid fa-book-open fa-2x" aria-hidden="true"></i>
+                    <h3>Fiches méthodes et entraînement</h3>
+                    <p>Consolidez vos connaissances avec nos fiches.</p>
+                </div>
+                <div class="service-card">
+                    <i class="fa-solid fa-compass fa-2x" aria-hidden="true"></i>
+                    <h3>Conseils orientation écoles</h3>
+                    <p>Nos experts vous guident vers les écoles qui vous correspondent.</p>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary
- design new `Nos services` section with cards and icons
- style services section with dark theme and hover effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e0d74ac0832d805fd42d7eb30d37