### PR TITLE
Apply light glassmorphism style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,9 +68,13 @@ main {
 }
 
 section {
-  background: var(--section-bg);
+  background: rgba(18, 18, 18, 0.7);
   padding: 4rem 2rem;
   border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Limit text width for better readability */
@@ -95,20 +99,28 @@ h3 {
   align-items: center;
   text-align: center;
   gap: 1rem;
-  background: #0d1117;
+  background: rgba(13, 17, 23, 0.7);
   color: #fff;
   padding: 4rem 2rem;
   border-radius: 8px;
   min-height: 80vh;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 /* Mission section */
 .mission-section {
-  background: #121212;
+  background: rgba(18, 18, 18, 0.7);
   color: #fff;
   text-align: center;
   padding: 4rem 2rem;
   line-height: 1.6;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .mission-section h2 {
@@ -124,10 +136,14 @@ h3 {
 
 /* Qui sommes-nous section */
 .qui-sommes-nous {
-  background: #1a1a1a;
+  background: rgba(26, 26, 26, 0.7);
   color: #fff;
   padding: 4rem 2rem;
   text-align: left;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 600px) {
@@ -167,6 +183,14 @@ button:hover {
 }
 
 /* Grid styles for lists */
+.valeurs {
+  background: rgba(18, 18, 18, 0.7);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 .valeurs ul,
 footer ul {
   display: grid;
@@ -177,8 +201,12 @@ footer ul {
 
 /* Pourquoi nous choisir */
 .pourquoi {
-  background: #121212;
+  background: rgba(18, 18, 18, 0.7);
   color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .pourquoi .cards {
@@ -189,10 +217,14 @@ footer ul {
 }
 
 .pourquoi .card {
-  background: #1e1e1e;
+  background: rgba(30, 30, 30, 0.7);
   padding: 2rem;
   border-radius: 8px;
   text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .pourquoi .card i {
@@ -202,8 +234,12 @@ footer ul {
 
 /* Services section */
 .services {
-  background: #121212;
+  background: rgba(18, 18, 18, 0.7);
   color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .service-cards {
@@ -214,11 +250,15 @@ footer ul {
 }
 
 .service-card {
-  background: #1e1e1e;
+  background: rgba(30, 30, 30, 0.7);
   padding: 2rem;
   border-radius: 8px;
   text-align: center;
   transition: transform 0.3s, box-shadow 0.3s;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .service-card:hover {
@@ -233,7 +273,7 @@ footer ul {
 
 /* Pourquoi ce projet */
 .projet-section {
-  background: #181818;
+  background: rgba(24, 24, 24, 0.7);
   color: #fff;
   max-width: 800px;
   margin: 0 auto;
@@ -242,6 +282,10 @@ footer ul {
   flex-direction: column;
   gap: 1.25rem;
   text-align: left;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 600px) {
@@ -265,8 +309,12 @@ footer ul {
 
 /* Cours section */
 .cours {
-  background: #0e0e0e;
+  background: rgba(14, 14, 14, 0.7);
   color: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .cours-grid {
@@ -278,12 +326,16 @@ footer ul {
 }
 
 .cours-item {
-  background: #1e1e1e;
+  background: rgba(30, 30, 30, 0.7);
   padding: 1.5rem;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .rythme,


### PR DESCRIPTION
## Summary
- enhance all sections with blurred glassmorphism background and light shadow
- style cards, service items and other blocks with semi-transparent backgrounds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872edf1e3e4832d84b66dbcc58818ca